### PR TITLE
Fix worktree deletion from inside the worktree directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.1] - 2025-06-16
+
+### Fixed
+- Clarified .gitignore skip message to explicitly state "Not adding to .gitignore" instead of just "already ignored by git"
+- Makes it clearer that the action being skipped is adding to the .gitignore file
+
 ## [1.2.0] - 2025-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.0] - 2025-06-16
+
+### Added
+- Smart .gitignore detection: Now uses `git check-ignore` to detect if files are already ignored before adding them to .gitignore
+- Prevents redundant .gitignore entries when patterns like `**/CLAUDE.md` already cover specific files like `apps/web/CLAUDE.md`
+
+### Fixed
+- Fixed issue where already-ignored files would be unnecessarily added to .gitignore
+
 ## [1.0.0] - 2024-01-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.2.0] - 2025-06-16
+
+### Added
+- New `filesToCopy` configuration option for copying files once instead of symlinking
+- Files specified in `filesToCopy` are copied to new worktrees on creation
+- Useful for template files that need to be modified per-worktree (e.g., .env.example)
+- Supports same gitignore-style patterns as `filesToSync`
+- Copied files are also added to .gitignore if `addToGitignore` is enabled
+
+### Changed
+- Updated example configuration to include `filesToCopy` examples
+
 ## [1.1.1] - 2025-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.2] - 2025-06-18
+
+### Fixed
+- Fixed "Directory not empty" error when deleting a worktree from inside itself
+- Shell function now properly changes to main repository after deletion
+
 ## [1.2.1] - 2025-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1] - 2025-06-16
+
+### Fixed
+- Fixed directory pattern matching in .gitignore detection
+- Directories with trailing slashes (like `ai_plans/`) now correctly match patterns like `**/ai_plans`
+
 ## [1.1.0] - 2025-06-16
 
 ### Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,8 @@ const CONFIG_FILENAME = 'swtconfig.toml';
 const DEFAULT_CONFIG = {
   defaultWorktreeDir: '../',
   addToGitignore: true,
-  filesToSync: []
+  filesToSync: [],
+  filesToCopy: []
 };
 
 /**
@@ -101,6 +102,14 @@ filesToSync = [
   # ".vscode/settings.json", 
   # ".idea/workspace.xml"
 ]
+
+# Files to copy once to new worktrees (gitignore syntax)
+# These files will be copied instead of symlinked
+filesToCopy = [
+  # "# Template files",
+  # ".env.example",
+  # "config/local.example.js"
+]
 `;
 
   try {
@@ -168,5 +177,6 @@ module.exports = {
   getConfigPath,
   resolveWorktreeDir,
   parseFilesToSync,
+  parseFilesToCopy: parseFilesToSync, // Same parsing logic
   CONFIG_FILENAME
 };

--- a/lib/create-worktree.js
+++ b/lib/create-worktree.js
@@ -42,8 +42,11 @@ async function createWorktree(name, options = {}) {
 
     console.log(chalk.green('✔ Worktree created successfully'));
 
-    // Sync files if configured
-    if (config.filesToSync && config.filesToSync.length > 0) {
+    // Sync/copy files if configured
+    const hasFilesToSync = config.filesToSync && config.filesToSync.length > 0;
+    const hasFilesToCopy = config.filesToCopy && config.filesToCopy.length > 0;
+    
+    if (hasFilesToSync || hasFilesToCopy) {
       console.log(chalk.blue('\nSyncing files from configuration...'));
       await syncFiles(gitRoot, worktreePath);
     }

--- a/lib/delete-worktree.js
+++ b/lib/delete-worktree.js
@@ -87,6 +87,8 @@ async function deleteWorktreeByPath(worktreePath, mainRepo, options = {}) {
     // Show appropriate message based on where we are
     if (inTargetWorktree) {
       console.log(chalk.cyan(`\nMain repository: ${mainRepo}`));
+      // Output a special marker for the shell function to detect
+      console.log(`__SWT_DELETED_FROM_INSIDE__:${mainRepo}`);
     } else {
       console.log(chalk.cyan(`\nDeleted: ${worktreePath}`));
     }

--- a/lib/shell-functions.js
+++ b/lib/shell-functions.js
@@ -16,19 +16,14 @@ swt() {
             fi
             ;;
         d|delete)
-            # If name provided, just run the command normally
-            if [ $# -gt 1 ]; then
-                command swt "$@"
-            else
-                # No name provided, delete current worktree
-                main_repo=$(git worktree list | head -n1 | awk '{print $1}')
-                current_dir=$(pwd)
-                # Run command without capturing output to allow interactive prompts
-                command swt "$@"
-                # If we're no longer in the worktree directory, it was deleted
-                if [ ! -d "$current_dir/.git" ]; then
-                    cd "$main_repo"
-                fi
+            # Capture output to check for special marker
+            output=$(command swt "$@" 2>&1)
+            # Check if we deleted from inside and need to change directory
+            new_dir=$(echo "$output" | grep -o "__SWT_DELETED_FROM_INSIDE__:.*" | sed 's/__SWT_DELETED_FROM_INSIDE__://')
+            # Remove the marker line from output before displaying
+            echo "$output" | grep -v "__SWT_DELETED_FROM_INSIDE__"
+            if [ -n "$new_dir" ] && [ -d "$new_dir" ]; then
+                cd "$new_dir"
             fi
             ;;
         cd)

--- a/lib/sync-files.js
+++ b/lib/sync-files.js
@@ -3,29 +3,44 @@ const path = require('path');
 const chalk = require('chalk');
 const { minimatch } = require('minimatch');
 const { execSync } = require('child_process');
-const { loadConfig, parseFilesToSync } = require('./config');
+const { loadConfig, parseFilesToSync, parseFilesToCopy } = require('./config');
 
 async function syncFiles(sourceRoot, targetRoot) {
   // Load config and get patterns
   const config = loadConfig();
-  const patterns = parseFilesToSync(config.filesToSync || []);
+  const syncPatterns = parseFilesToSync(config.filesToSync || []);
+  const copyPatterns = parseFilesToCopy(config.filesToCopy || []);
 
-  if (patterns.length === 0) {
-    return;
+  // Handle file copying first
+  if (copyPatterns.length > 0) {
+    console.log(chalk.gray(`Copying ${copyPatterns.length} pattern(s)...`));
+    
+    const copiedPaths = [];
+    for (const pattern of copyPatterns) {
+      const paths = await copyPattern(sourceRoot, targetRoot, pattern);
+      copiedPaths.push(...paths);
+    }
+    
+    // Update .gitignore with copied paths if enabled in config
+    if (copiedPaths.length > 0 && config.addToGitignore !== false) {
+      await updateGitignore(targetRoot, copiedPaths);
+    }
   }
 
-  console.log(chalk.gray(`Syncing ${patterns.length} pattern(s)...`));
+  // Handle file syncing (symlinks)
+  if (syncPatterns.length > 0) {
+    console.log(chalk.gray(`Syncing ${syncPatterns.length} pattern(s)...`));
 
-  const syncedPaths = [];
-  
-  for (const pattern of patterns) {
-    const paths = await syncPattern(sourceRoot, targetRoot, pattern);
-    syncedPaths.push(...paths);
-  }
+    const syncedPaths = [];
+    for (const pattern of syncPatterns) {
+      const paths = await syncPattern(sourceRoot, targetRoot, pattern);
+      syncedPaths.push(...paths);
+    }
 
-  // Update .gitignore with synced paths if enabled in config
-  if (syncedPaths.length > 0 && config.addToGitignore !== false) {
-    await updateGitignore(targetRoot, syncedPaths);
+    // Update .gitignore with synced paths if enabled in config
+    if (syncedPaths.length > 0 && config.addToGitignore !== false) {
+      await updateGitignore(targetRoot, syncedPaths);
+    }
   }
 }
 
@@ -72,6 +87,50 @@ async function syncPattern(sourceRoot, targetRoot, pattern) {
   }
   
   return syncedPaths;
+}
+
+async function copyPattern(sourceRoot, targetRoot, pattern) {
+  const copiedPaths = [];
+  
+  // Handle negation patterns (starting with !)
+  if (pattern.startsWith('!')) {
+    // For now, we'll skip negation patterns
+    return copiedPaths;
+  }
+
+  // Handle directory patterns (ending with /)
+  if (pattern.endsWith('/')) {
+    const dirPath = pattern.slice(0, -1);
+    const sourcePath = path.join(sourceRoot, dirPath);
+    const targetPath = path.join(targetRoot, dirPath);
+
+    if (fs.existsSync(sourcePath) && fs.lstatSync(sourcePath).isDirectory()) {
+      if (copyDirectory(sourcePath, targetPath)) {
+        copiedPaths.push(dirPath + '/');
+      }
+    }
+    return copiedPaths;
+  }
+
+  // Handle glob patterns
+  const files = findMatchingFiles(sourceRoot, pattern);
+  
+  for (const file of files) {
+    const sourcePath = path.join(sourceRoot, file);
+    const targetPath = path.join(targetRoot, file);
+    
+    // Create parent directory if needed
+    const targetDir = path.dirname(targetPath);
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir, { recursive: true });
+    }
+
+    if (copyFile(sourcePath, targetPath)) {
+      copiedPaths.push(file);
+    }
+  }
+  
+  return copiedPaths;
 }
 
 function findMatchingFiles(root, pattern) {
@@ -130,6 +189,56 @@ function createSymlink(source, target, type) {
     return true;
   } catch (error) {
     console.warn(chalk.yellow(`  ⚠ Failed to link ${target}: ${error.message}`));
+    return false;
+  }
+}
+
+function copyFile(source, target) {
+  // Skip if target already exists
+  if (fs.existsSync(target)) {
+    return false;
+  }
+
+  try {
+    fs.copyFileSync(source, target);
+    const displayPath = path.relative(process.cwd(), target);
+    console.log(chalk.green(`  ✓ Copied: ${displayPath}`));
+    return true;
+  } catch (error) {
+    console.warn(chalk.yellow(`  ⚠ Failed to copy ${target}: ${error.message}`));
+    return false;
+  }
+}
+
+function copyDirectory(source, target) {
+  // Skip if target already exists
+  if (fs.existsSync(target)) {
+    return false;
+  }
+
+  try {
+    // Create target directory
+    fs.mkdirSync(target, { recursive: true });
+    
+    // Copy all contents recursively
+    const entries = fs.readdirSync(source, { withFileTypes: true });
+    
+    for (const entry of entries) {
+      const sourcePath = path.join(source, entry.name);
+      const targetPath = path.join(target, entry.name);
+      
+      if (entry.isDirectory()) {
+        copyDirectory(sourcePath, targetPath);
+      } else {
+        fs.copyFileSync(sourcePath, targetPath);
+      }
+    }
+    
+    const displayPath = path.relative(process.cwd(), target);
+    console.log(chalk.green(`  ✓ Copied directory: ${displayPath}`));
+    return true;
+  } catch (error) {
+    console.warn(chalk.yellow(`  ⚠ Failed to copy directory ${target}: ${error.message}`));
     return false;
   }
 }

--- a/lib/sync-files.js
+++ b/lib/sync-files.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 const { minimatch } = require('minimatch');
+const { execSync } = require('child_process');
 const { loadConfig, parseFilesToSync } = require('./config');
 
 async function syncFiles(sourceRoot, targetRoot) {
@@ -133,6 +134,19 @@ function createSymlink(source, target, type) {
   }
 }
 
+function isIgnoredByGit(filePath, cwd) {
+  try {
+    // Use git check-ignore to see if the file would be ignored
+    execSync(`git check-ignore "${filePath}"`, { 
+      cwd: cwd,
+      stdio: 'pipe' 
+    });
+    return true; // If command succeeds, file is ignored
+  } catch {
+    return false; // If command fails, file is not ignored
+  }
+}
+
 async function updateGitignore(targetRoot, syncedPaths) {
   const gitignorePath = path.join(targetRoot, '.gitignore');
   
@@ -159,10 +173,16 @@ async function updateGitignore(targetRoot, syncedPaths) {
   // Find new patterns to add
   const newPatterns = [];
   for (const syncedPath of syncedPaths) {
+    // First check if git already ignores this file
+    if (isIgnoredByGit(syncedPath, targetRoot)) {
+      console.log(chalk.gray(`  • Skipping ${syncedPath} (already ignored by git)`));
+      continue;
+    }
+    
     // Normalize for comparison (remove trailing slash)
     const normalizedPath = syncedPath.replace(/\/$/, '');
     
-    // Check if pattern already exists
+    // Check if pattern already exists in .gitignore
     if (!existingPatterns.has(normalizedPath)) {
       newPatterns.push(syncedPath);
     }

--- a/lib/sync-files.js
+++ b/lib/sync-files.js
@@ -136,8 +136,12 @@ function createSymlink(source, target, type) {
 
 function isIgnoredByGit(filePath, cwd) {
   try {
+    // For directories, we need to check without the trailing slash
+    // because .gitignore patterns like **/ai_plans match directories without trailing slash
+    const pathToCheck = filePath.endsWith('/') ? filePath.slice(0, -1) : filePath;
+    
     // Use git check-ignore to see if the file would be ignored
-    execSync(`git check-ignore "${filePath}"`, { 
+    execSync(`git check-ignore "${pathToCheck}"`, { 
       cwd: cwd,
       stdio: 'pipe' 
     });

--- a/lib/sync-files.js
+++ b/lib/sync-files.js
@@ -288,7 +288,7 @@ async function updateGitignore(targetRoot, syncedPaths) {
   for (const syncedPath of syncedPaths) {
     // First check if git already ignores this file
     if (isIgnoredByGit(syncedPath, targetRoot)) {
-      console.log(chalk.gray(`  • Skipping ${syncedPath} (already ignored by git)`));
+      console.log(chalk.gray(`  • Not adding ${syncedPath} to .gitignore (already ignored by existing patterns)`));
       continue;
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-worktree",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simplify git worktree management with automatic file syncing between worktrees",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-worktree",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Simplify git worktree management with automatic file syncing between worktrees",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-worktree",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Simplify git worktree management with automatic file syncing between worktrees",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-worktree",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Simplify git worktree management with automatic file syncing between worktrees",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-worktree",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simplify git worktree management with automatic file syncing between worktrees",
   "keywords": [
     "git",

--- a/swtconfig.example.toml
+++ b/swtconfig.example.toml
@@ -43,3 +43,20 @@ filesToSync = [
   # "scripts/local/",
   # ".personal-scripts/"
 ]
+
+# Files to copy once to new worktrees (gitignore syntax)
+# These files will be copied instead of symlinked
+# Useful for template files that need to be modified per-worktree
+filesToCopy = [
+  # Template/example files
+  # ".env.example",
+  # "config/local.example.js",
+  
+  # Initial setup files
+  # "scripts/setup-local.sh",
+  # "docker-compose.override.example.yml",
+  
+  # Per-worktree configuration templates
+  # ".vscode/launch.example.json",
+  # "config/database.example.json"
+]


### PR DESCRIPTION
## Summary
- Fixed "Directory not empty" error when deleting a worktree from inside itself
- Added special marker output when deleting from inside that the shell function detects
- Shell function now automatically changes to main repository after deletion

## Problem
When running `wt d` or `swt d` from inside a worktree, the command would fail with:
```
Error: Failed to delete worktree: Command failed: git worktree remove "/path/to/worktree" --force
error: failed to delete '/path/to/worktree': Directory not empty
```

This happened because the shell's current directory was still inside the worktree being deleted.

## Solution
1. The delete-worktree.js now outputs a special marker `__SWT_DELETED_FROM_INSIDE__:` followed by the main repo path when deleting from inside
2. The shell function captures this marker, extracts the main repo path, and automatically changes to it
3. The marker is filtered out from the displayed output so users don't see it

## Test plan
- [x] Test deleting a worktree from inside itself with `wt d`
- [x] Test deleting a worktree by name from outside with `wt d <name>`
- [x] Verify shell changes to main repo after deletion from inside
- [x] Verify no marker text appears in output
- [x] Update version to 1.2.2
- [x] Update CHANGELOG.md